### PR TITLE
Clean Up C++ Code

### DIFF
--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -8,36 +8,36 @@
 using namespace Rcpp;
 
 // ProxL1
-arma::colvec ProxL1(arma::colvec delta, int p, double lambda, arma::colvec weights);
+arma::colvec ProxL1(const arma::colvec& delta, int p, double lambda, const arma::colvec& weights);
 RcppExport SEXP _clustRviz_ProxL1(SEXP deltaSEXP, SEXP pSEXP, SEXP lambdaSEXP, SEXP weightsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< arma::colvec >::type delta(deltaSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type delta(deltaSEXP);
     Rcpp::traits::input_parameter< int >::type p(pSEXP);
     Rcpp::traits::input_parameter< double >::type lambda(lambdaSEXP);
-    Rcpp::traits::input_parameter< arma::colvec >::type weights(weightsSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type weights(weightsSEXP);
     rcpp_result_gen = Rcpp::wrap(ProxL1(delta, p, lambda, weights));
     return rcpp_result_gen;
 END_RCPP
 }
 // CARPL2_VIS_FRAC
-Rcpp::List CARPL2_VIS_FRAC(arma::colvec x, int n, int p, double lambda_init, arma::colvec weights, arma::colvec uinit, arma::colvec vinit, Eigen::SparseMatrix<double> premat, arma::umat IndMat, arma::umat EOneIndMat, arma::umat ETwoIndMat, double rho, int max_iter, int burn_in, bool verbose, double back, double try_tol, int ti, double t_switch, int keep);
+Rcpp::List CARPL2_VIS_FRAC(const arma::colvec& x, int n, int p, double lambda_init, const arma::colvec& weights, const arma::colvec& uinit, const arma::colvec& vinit, const Eigen::SparseMatrix<double>& premat, const arma::umat& IndMat, const arma::umat& EOneIndMat, const arma::umat& ETwoIndMat, double rho, int max_iter, int burn_in, bool verbose, double back, double try_tol, int ti, double t_switch, int keep);
 RcppExport SEXP _clustRviz_CARPL2_VIS_FRAC(SEXP xSEXP, SEXP nSEXP, SEXP pSEXP, SEXP lambda_initSEXP, SEXP weightsSEXP, SEXP uinitSEXP, SEXP vinitSEXP, SEXP prematSEXP, SEXP IndMatSEXP, SEXP EOneIndMatSEXP, SEXP ETwoIndMatSEXP, SEXP rhoSEXP, SEXP max_iterSEXP, SEXP burn_inSEXP, SEXP verboseSEXP, SEXP backSEXP, SEXP try_tolSEXP, SEXP tiSEXP, SEXP t_switchSEXP, SEXP keepSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< arma::colvec >::type x(xSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type x(xSEXP);
     Rcpp::traits::input_parameter< int >::type n(nSEXP);
     Rcpp::traits::input_parameter< int >::type p(pSEXP);
     Rcpp::traits::input_parameter< double >::type lambda_init(lambda_initSEXP);
-    Rcpp::traits::input_parameter< arma::colvec >::type weights(weightsSEXP);
-    Rcpp::traits::input_parameter< arma::colvec >::type uinit(uinitSEXP);
-    Rcpp::traits::input_parameter< arma::colvec >::type vinit(vinitSEXP);
-    Rcpp::traits::input_parameter< Eigen::SparseMatrix<double> >::type premat(prematSEXP);
-    Rcpp::traits::input_parameter< arma::umat >::type IndMat(IndMatSEXP);
-    Rcpp::traits::input_parameter< arma::umat >::type EOneIndMat(EOneIndMatSEXP);
-    Rcpp::traits::input_parameter< arma::umat >::type ETwoIndMat(ETwoIndMatSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type weights(weightsSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type uinit(uinitSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type vinit(vinitSEXP);
+    Rcpp::traits::input_parameter< const Eigen::SparseMatrix<double>& >::type premat(prematSEXP);
+    Rcpp::traits::input_parameter< const arma::umat& >::type IndMat(IndMatSEXP);
+    Rcpp::traits::input_parameter< const arma::umat& >::type EOneIndMat(EOneIndMatSEXP);
+    Rcpp::traits::input_parameter< const arma::umat& >::type ETwoIndMat(ETwoIndMatSEXP);
     Rcpp::traits::input_parameter< double >::type rho(rhoSEXP);
     Rcpp::traits::input_parameter< int >::type max_iter(max_iterSEXP);
     Rcpp::traits::input_parameter< int >::type burn_in(burn_inSEXP);
@@ -52,23 +52,23 @@ BEGIN_RCPP
 END_RCPP
 }
 // CARPL2_NF_FRAC
-Rcpp::List CARPL2_NF_FRAC(arma::colvec x, int n, int p, double lambda_init, double t, arma::colvec weights, arma::colvec uinit, arma::colvec vinit, Eigen::SparseMatrix<double> premat, arma::umat IndMat, arma::umat EOneIndMat, arma::umat ETwoIndMat, double rho, int max_iter, int burn_in, bool verbose, int keep);
+Rcpp::List CARPL2_NF_FRAC(const arma::colvec& x, int n, int p, double lambda_init, double t, const arma::colvec& weights, const arma::colvec& uinit, const arma::colvec& vinit, const Eigen::SparseMatrix<double>& premat, const arma::umat& IndMat, const arma::umat& EOneIndMat, const arma::umat& ETwoIndMat, double rho, int max_iter, int burn_in, bool verbose, int keep);
 RcppExport SEXP _clustRviz_CARPL2_NF_FRAC(SEXP xSEXP, SEXP nSEXP, SEXP pSEXP, SEXP lambda_initSEXP, SEXP tSEXP, SEXP weightsSEXP, SEXP uinitSEXP, SEXP vinitSEXP, SEXP prematSEXP, SEXP IndMatSEXP, SEXP EOneIndMatSEXP, SEXP ETwoIndMatSEXP, SEXP rhoSEXP, SEXP max_iterSEXP, SEXP burn_inSEXP, SEXP verboseSEXP, SEXP keepSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< arma::colvec >::type x(xSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type x(xSEXP);
     Rcpp::traits::input_parameter< int >::type n(nSEXP);
     Rcpp::traits::input_parameter< int >::type p(pSEXP);
     Rcpp::traits::input_parameter< double >::type lambda_init(lambda_initSEXP);
     Rcpp::traits::input_parameter< double >::type t(tSEXP);
-    Rcpp::traits::input_parameter< arma::colvec >::type weights(weightsSEXP);
-    Rcpp::traits::input_parameter< arma::colvec >::type uinit(uinitSEXP);
-    Rcpp::traits::input_parameter< arma::colvec >::type vinit(vinitSEXP);
-    Rcpp::traits::input_parameter< Eigen::SparseMatrix<double> >::type premat(prematSEXP);
-    Rcpp::traits::input_parameter< arma::umat >::type IndMat(IndMatSEXP);
-    Rcpp::traits::input_parameter< arma::umat >::type EOneIndMat(EOneIndMatSEXP);
-    Rcpp::traits::input_parameter< arma::umat >::type ETwoIndMat(ETwoIndMatSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type weights(weightsSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type uinit(uinitSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type vinit(vinitSEXP);
+    Rcpp::traits::input_parameter< const Eigen::SparseMatrix<double>& >::type premat(prematSEXP);
+    Rcpp::traits::input_parameter< const arma::umat& >::type IndMat(IndMatSEXP);
+    Rcpp::traits::input_parameter< const arma::umat& >::type EOneIndMat(EOneIndMatSEXP);
+    Rcpp::traits::input_parameter< const arma::umat& >::type ETwoIndMat(ETwoIndMatSEXP);
     Rcpp::traits::input_parameter< double >::type rho(rhoSEXP);
     Rcpp::traits::input_parameter< int >::type max_iter(max_iterSEXP);
     Rcpp::traits::input_parameter< int >::type burn_in(burn_inSEXP);
@@ -79,23 +79,23 @@ BEGIN_RCPP
 END_RCPP
 }
 // CARPL1_NF_FRAC
-Rcpp::List CARPL1_NF_FRAC(arma::colvec x, int n, int p, double lambda_init, double t, arma::colvec weights, arma::colvec uinit, arma::colvec vinit, Eigen::SparseMatrix<double> premat, arma::umat IndMat, arma::umat EOneIndMat, arma::umat ETwoIndMat, double rho, int max_iter, int burn_in, bool verbose, int keep);
+Rcpp::List CARPL1_NF_FRAC(const arma::colvec& x, int n, int p, double lambda_init, double t, const arma::colvec& weights, const arma::colvec& uinit, const arma::colvec& vinit, const Eigen::SparseMatrix<double>& premat, const arma::umat& IndMat, const arma::umat& EOneIndMat, const arma::umat& ETwoIndMat, double rho, int max_iter, int burn_in, bool verbose, int keep);
 RcppExport SEXP _clustRviz_CARPL1_NF_FRAC(SEXP xSEXP, SEXP nSEXP, SEXP pSEXP, SEXP lambda_initSEXP, SEXP tSEXP, SEXP weightsSEXP, SEXP uinitSEXP, SEXP vinitSEXP, SEXP prematSEXP, SEXP IndMatSEXP, SEXP EOneIndMatSEXP, SEXP ETwoIndMatSEXP, SEXP rhoSEXP, SEXP max_iterSEXP, SEXP burn_inSEXP, SEXP verboseSEXP, SEXP keepSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< arma::colvec >::type x(xSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type x(xSEXP);
     Rcpp::traits::input_parameter< int >::type n(nSEXP);
     Rcpp::traits::input_parameter< int >::type p(pSEXP);
     Rcpp::traits::input_parameter< double >::type lambda_init(lambda_initSEXP);
     Rcpp::traits::input_parameter< double >::type t(tSEXP);
-    Rcpp::traits::input_parameter< arma::colvec >::type weights(weightsSEXP);
-    Rcpp::traits::input_parameter< arma::colvec >::type uinit(uinitSEXP);
-    Rcpp::traits::input_parameter< arma::colvec >::type vinit(vinitSEXP);
-    Rcpp::traits::input_parameter< Eigen::SparseMatrix<double> >::type premat(prematSEXP);
-    Rcpp::traits::input_parameter< arma::umat >::type IndMat(IndMatSEXP);
-    Rcpp::traits::input_parameter< arma::umat >::type EOneIndMat(EOneIndMatSEXP);
-    Rcpp::traits::input_parameter< arma::umat >::type ETwoIndMat(ETwoIndMatSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type weights(weightsSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type uinit(uinitSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type vinit(vinitSEXP);
+    Rcpp::traits::input_parameter< const Eigen::SparseMatrix<double>& >::type premat(prematSEXP);
+    Rcpp::traits::input_parameter< const arma::umat& >::type IndMat(IndMatSEXP);
+    Rcpp::traits::input_parameter< const arma::umat& >::type EOneIndMat(EOneIndMatSEXP);
+    Rcpp::traits::input_parameter< const arma::umat& >::type ETwoIndMat(ETwoIndMatSEXP);
     Rcpp::traits::input_parameter< double >::type rho(rhoSEXP);
     Rcpp::traits::input_parameter< int >::type max_iter(max_iterSEXP);
     Rcpp::traits::input_parameter< int >::type burn_in(burn_inSEXP);
@@ -106,22 +106,22 @@ BEGIN_RCPP
 END_RCPP
 }
 // CARPL1_VIS_FRAC
-Rcpp::List CARPL1_VIS_FRAC(arma::colvec x, int n, int p, double lambda_init, arma::colvec weights, arma::colvec uinit, arma::colvec vinit, Eigen::SparseMatrix<double> premat, arma::umat IndMat, arma::umat EOneIndMat, arma::umat ETwoIndMat, double rho, int max_iter, int burn_in, bool verbose, double back, double try_tol, int ti, double t_switch, int keep);
+Rcpp::List CARPL1_VIS_FRAC(const arma::colvec& x, int n, int p, double lambda_init, const arma::colvec& weights, const arma::colvec& uinit, const arma::colvec& vinit, const Eigen::SparseMatrix<double>& premat, const arma::umat& IndMat, const arma::umat& EOneIndMat, const arma::umat& ETwoIndMat, double rho, int max_iter, int burn_in, bool verbose, double back, double try_tol, int ti, double t_switch, int keep);
 RcppExport SEXP _clustRviz_CARPL1_VIS_FRAC(SEXP xSEXP, SEXP nSEXP, SEXP pSEXP, SEXP lambda_initSEXP, SEXP weightsSEXP, SEXP uinitSEXP, SEXP vinitSEXP, SEXP prematSEXP, SEXP IndMatSEXP, SEXP EOneIndMatSEXP, SEXP ETwoIndMatSEXP, SEXP rhoSEXP, SEXP max_iterSEXP, SEXP burn_inSEXP, SEXP verboseSEXP, SEXP backSEXP, SEXP try_tolSEXP, SEXP tiSEXP, SEXP t_switchSEXP, SEXP keepSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< arma::colvec >::type x(xSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type x(xSEXP);
     Rcpp::traits::input_parameter< int >::type n(nSEXP);
     Rcpp::traits::input_parameter< int >::type p(pSEXP);
     Rcpp::traits::input_parameter< double >::type lambda_init(lambda_initSEXP);
-    Rcpp::traits::input_parameter< arma::colvec >::type weights(weightsSEXP);
-    Rcpp::traits::input_parameter< arma::colvec >::type uinit(uinitSEXP);
-    Rcpp::traits::input_parameter< arma::colvec >::type vinit(vinitSEXP);
-    Rcpp::traits::input_parameter< Eigen::SparseMatrix<double> >::type premat(prematSEXP);
-    Rcpp::traits::input_parameter< arma::umat >::type IndMat(IndMatSEXP);
-    Rcpp::traits::input_parameter< arma::umat >::type EOneIndMat(EOneIndMatSEXP);
-    Rcpp::traits::input_parameter< arma::umat >::type ETwoIndMat(ETwoIndMatSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type weights(weightsSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type uinit(uinitSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type vinit(vinitSEXP);
+    Rcpp::traits::input_parameter< const Eigen::SparseMatrix<double>& >::type premat(prematSEXP);
+    Rcpp::traits::input_parameter< const arma::umat& >::type IndMat(IndMatSEXP);
+    Rcpp::traits::input_parameter< const arma::umat& >::type EOneIndMat(EOneIndMatSEXP);
+    Rcpp::traits::input_parameter< const arma::umat& >::type ETwoIndMat(ETwoIndMatSEXP);
     Rcpp::traits::input_parameter< double >::type rho(rhoSEXP);
     Rcpp::traits::input_parameter< int >::type max_iter(max_iterSEXP);
     Rcpp::traits::input_parameter< int >::type burn_in(burn_inSEXP);
@@ -136,29 +136,29 @@ BEGIN_RCPP
 END_RCPP
 }
 // BICARPL2_VIS
-Rcpp::List BICARPL2_VIS(arma::colvec x, int n, int p, double lambda_init, arma::colvec weights_col, arma::colvec weights_row, arma::colvec uinit_row, arma::colvec uinit_col, arma::colvec vinit_row, arma::colvec vinit_col, Eigen::SparseMatrix<double> premat_row, Eigen::SparseMatrix<double> premat_col, arma::umat IndMat_row, arma::umat IndMat_col, arma::umat EOneIndMat_row, arma::umat EOneIndMat_col, arma::umat ETwoIndMat_row, arma::umat ETwoIndMat_col, double rho, int max_iter, int burn_in, bool verbose, bool verbose_inner, double try_tol, int ti, double t_switch);
+Rcpp::List BICARPL2_VIS(const arma::colvec& x, int n, int p, double lambda_init, const arma::colvec& weights_col, const arma::colvec& weights_row, const arma::colvec& uinit_row, const arma::colvec& uinit_col, const arma::colvec& vinit_row, const arma::colvec& vinit_col, const Eigen::SparseMatrix<double>& premat_row, const Eigen::SparseMatrix<double>& premat_col, const arma::umat& IndMat_row, const arma::umat& IndMat_col, const arma::umat& EOneIndMat_row, const arma::umat& EOneIndMat_col, const arma::umat& ETwoIndMat_row, const arma::umat& ETwoIndMat_col, double rho, int max_iter, int burn_in, bool verbose, bool verbose_inner, double try_tol, int ti, double t_switch);
 RcppExport SEXP _clustRviz_BICARPL2_VIS(SEXP xSEXP, SEXP nSEXP, SEXP pSEXP, SEXP lambda_initSEXP, SEXP weights_colSEXP, SEXP weights_rowSEXP, SEXP uinit_rowSEXP, SEXP uinit_colSEXP, SEXP vinit_rowSEXP, SEXP vinit_colSEXP, SEXP premat_rowSEXP, SEXP premat_colSEXP, SEXP IndMat_rowSEXP, SEXP IndMat_colSEXP, SEXP EOneIndMat_rowSEXP, SEXP EOneIndMat_colSEXP, SEXP ETwoIndMat_rowSEXP, SEXP ETwoIndMat_colSEXP, SEXP rhoSEXP, SEXP max_iterSEXP, SEXP burn_inSEXP, SEXP verboseSEXP, SEXP verbose_innerSEXP, SEXP try_tolSEXP, SEXP tiSEXP, SEXP t_switchSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< arma::colvec >::type x(xSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type x(xSEXP);
     Rcpp::traits::input_parameter< int >::type n(nSEXP);
     Rcpp::traits::input_parameter< int >::type p(pSEXP);
     Rcpp::traits::input_parameter< double >::type lambda_init(lambda_initSEXP);
-    Rcpp::traits::input_parameter< arma::colvec >::type weights_col(weights_colSEXP);
-    Rcpp::traits::input_parameter< arma::colvec >::type weights_row(weights_rowSEXP);
-    Rcpp::traits::input_parameter< arma::colvec >::type uinit_row(uinit_rowSEXP);
-    Rcpp::traits::input_parameter< arma::colvec >::type uinit_col(uinit_colSEXP);
-    Rcpp::traits::input_parameter< arma::colvec >::type vinit_row(vinit_rowSEXP);
-    Rcpp::traits::input_parameter< arma::colvec >::type vinit_col(vinit_colSEXP);
-    Rcpp::traits::input_parameter< Eigen::SparseMatrix<double> >::type premat_row(premat_rowSEXP);
-    Rcpp::traits::input_parameter< Eigen::SparseMatrix<double> >::type premat_col(premat_colSEXP);
-    Rcpp::traits::input_parameter< arma::umat >::type IndMat_row(IndMat_rowSEXP);
-    Rcpp::traits::input_parameter< arma::umat >::type IndMat_col(IndMat_colSEXP);
-    Rcpp::traits::input_parameter< arma::umat >::type EOneIndMat_row(EOneIndMat_rowSEXP);
-    Rcpp::traits::input_parameter< arma::umat >::type EOneIndMat_col(EOneIndMat_colSEXP);
-    Rcpp::traits::input_parameter< arma::umat >::type ETwoIndMat_row(ETwoIndMat_rowSEXP);
-    Rcpp::traits::input_parameter< arma::umat >::type ETwoIndMat_col(ETwoIndMat_colSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type weights_col(weights_colSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type weights_row(weights_rowSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type uinit_row(uinit_rowSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type uinit_col(uinit_colSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type vinit_row(vinit_rowSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type vinit_col(vinit_colSEXP);
+    Rcpp::traits::input_parameter< const Eigen::SparseMatrix<double>& >::type premat_row(premat_rowSEXP);
+    Rcpp::traits::input_parameter< const Eigen::SparseMatrix<double>& >::type premat_col(premat_colSEXP);
+    Rcpp::traits::input_parameter< const arma::umat& >::type IndMat_row(IndMat_rowSEXP);
+    Rcpp::traits::input_parameter< const arma::umat& >::type IndMat_col(IndMat_colSEXP);
+    Rcpp::traits::input_parameter< const arma::umat& >::type EOneIndMat_row(EOneIndMat_rowSEXP);
+    Rcpp::traits::input_parameter< const arma::umat& >::type EOneIndMat_col(EOneIndMat_colSEXP);
+    Rcpp::traits::input_parameter< const arma::umat& >::type ETwoIndMat_row(ETwoIndMat_rowSEXP);
+    Rcpp::traits::input_parameter< const arma::umat& >::type ETwoIndMat_col(ETwoIndMat_colSEXP);
     Rcpp::traits::input_parameter< double >::type rho(rhoSEXP);
     Rcpp::traits::input_parameter< int >::type max_iter(max_iterSEXP);
     Rcpp::traits::input_parameter< int >::type burn_in(burn_inSEXP);
@@ -172,29 +172,29 @@ BEGIN_RCPP
 END_RCPP
 }
 // BICARPL1_VIS
-Rcpp::List BICARPL1_VIS(arma::colvec x, int n, int p, double lambda_init, arma::colvec weights_col, arma::colvec weights_row, arma::colvec uinit_row, arma::colvec uinit_col, arma::colvec vinit_row, arma::colvec vinit_col, Eigen::SparseMatrix<double> premat_row, Eigen::SparseMatrix<double> premat_col, arma::umat IndMat_row, arma::umat IndMat_col, arma::umat EOneIndMat_row, arma::umat EOneIndMat_col, arma::umat ETwoIndMat_row, arma::umat ETwoIndMat_col, double rho, int max_iter, int burn_in, bool verbose, bool verbose_inner, double try_tol, int ti, double t_switch);
+Rcpp::List BICARPL1_VIS(const arma::colvec& x, int n, int p, double lambda_init, const arma::colvec& weights_col, const arma::colvec& weights_row, const arma::colvec& uinit_row, const arma::colvec& uinit_col, const arma::colvec& vinit_row, const arma::colvec& vinit_col, const Eigen::SparseMatrix<double>& premat_row, const Eigen::SparseMatrix<double>& premat_col, const arma::umat& IndMat_row, const arma::umat& IndMat_col, const arma::umat& EOneIndMat_row, const arma::umat& EOneIndMat_col, const arma::umat& ETwoIndMat_row, const arma::umat& ETwoIndMat_col, double rho, int max_iter, int burn_in, bool verbose, bool verbose_inner, double try_tol, int ti, double t_switch);
 RcppExport SEXP _clustRviz_BICARPL1_VIS(SEXP xSEXP, SEXP nSEXP, SEXP pSEXP, SEXP lambda_initSEXP, SEXP weights_colSEXP, SEXP weights_rowSEXP, SEXP uinit_rowSEXP, SEXP uinit_colSEXP, SEXP vinit_rowSEXP, SEXP vinit_colSEXP, SEXP premat_rowSEXP, SEXP premat_colSEXP, SEXP IndMat_rowSEXP, SEXP IndMat_colSEXP, SEXP EOneIndMat_rowSEXP, SEXP EOneIndMat_colSEXP, SEXP ETwoIndMat_rowSEXP, SEXP ETwoIndMat_colSEXP, SEXP rhoSEXP, SEXP max_iterSEXP, SEXP burn_inSEXP, SEXP verboseSEXP, SEXP verbose_innerSEXP, SEXP try_tolSEXP, SEXP tiSEXP, SEXP t_switchSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< arma::colvec >::type x(xSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type x(xSEXP);
     Rcpp::traits::input_parameter< int >::type n(nSEXP);
     Rcpp::traits::input_parameter< int >::type p(pSEXP);
     Rcpp::traits::input_parameter< double >::type lambda_init(lambda_initSEXP);
-    Rcpp::traits::input_parameter< arma::colvec >::type weights_col(weights_colSEXP);
-    Rcpp::traits::input_parameter< arma::colvec >::type weights_row(weights_rowSEXP);
-    Rcpp::traits::input_parameter< arma::colvec >::type uinit_row(uinit_rowSEXP);
-    Rcpp::traits::input_parameter< arma::colvec >::type uinit_col(uinit_colSEXP);
-    Rcpp::traits::input_parameter< arma::colvec >::type vinit_row(vinit_rowSEXP);
-    Rcpp::traits::input_parameter< arma::colvec >::type vinit_col(vinit_colSEXP);
-    Rcpp::traits::input_parameter< Eigen::SparseMatrix<double> >::type premat_row(premat_rowSEXP);
-    Rcpp::traits::input_parameter< Eigen::SparseMatrix<double> >::type premat_col(premat_colSEXP);
-    Rcpp::traits::input_parameter< arma::umat >::type IndMat_row(IndMat_rowSEXP);
-    Rcpp::traits::input_parameter< arma::umat >::type IndMat_col(IndMat_colSEXP);
-    Rcpp::traits::input_parameter< arma::umat >::type EOneIndMat_row(EOneIndMat_rowSEXP);
-    Rcpp::traits::input_parameter< arma::umat >::type EOneIndMat_col(EOneIndMat_colSEXP);
-    Rcpp::traits::input_parameter< arma::umat >::type ETwoIndMat_row(ETwoIndMat_rowSEXP);
-    Rcpp::traits::input_parameter< arma::umat >::type ETwoIndMat_col(ETwoIndMat_colSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type weights_col(weights_colSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type weights_row(weights_rowSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type uinit_row(uinit_rowSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type uinit_col(uinit_colSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type vinit_row(vinit_rowSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type vinit_col(vinit_colSEXP);
+    Rcpp::traits::input_parameter< const Eigen::SparseMatrix<double>& >::type premat_row(premat_rowSEXP);
+    Rcpp::traits::input_parameter< const Eigen::SparseMatrix<double>& >::type premat_col(premat_colSEXP);
+    Rcpp::traits::input_parameter< const arma::umat& >::type IndMat_row(IndMat_rowSEXP);
+    Rcpp::traits::input_parameter< const arma::umat& >::type IndMat_col(IndMat_colSEXP);
+    Rcpp::traits::input_parameter< const arma::umat& >::type EOneIndMat_row(EOneIndMat_rowSEXP);
+    Rcpp::traits::input_parameter< const arma::umat& >::type EOneIndMat_col(EOneIndMat_colSEXP);
+    Rcpp::traits::input_parameter< const arma::umat& >::type ETwoIndMat_row(ETwoIndMat_rowSEXP);
+    Rcpp::traits::input_parameter< const arma::umat& >::type ETwoIndMat_col(ETwoIndMat_colSEXP);
     Rcpp::traits::input_parameter< double >::type rho(rhoSEXP);
     Rcpp::traits::input_parameter< int >::type max_iter(max_iterSEXP);
     Rcpp::traits::input_parameter< int >::type burn_in(burn_inSEXP);
@@ -208,30 +208,30 @@ BEGIN_RCPP
 END_RCPP
 }
 // BICARPL2_NF_FRAC
-Rcpp::List BICARPL2_NF_FRAC(arma::colvec x, int n, int p, double lambda_init, double t, arma::colvec weights_row, arma::colvec weights_col, arma::colvec uinit_row, arma::colvec uinit_col, arma::colvec vinit_row, arma::colvec vinit_col, Eigen::SparseMatrix<double> premat_row, Eigen::SparseMatrix<double> premat_col, arma::umat IndMat_row, arma::umat IndMat_col, arma::umat EOneIndMat_row, arma::umat EOneIndMat_col, arma::umat ETwoIndMat_row, arma::umat ETwoIndMat_col, double rho, int max_iter, int burn_in, bool verbose, int keep);
+Rcpp::List BICARPL2_NF_FRAC(const arma::colvec& x, int n, int p, double lambda_init, double t, const arma::colvec& weights_row, const arma::colvec& weights_col, const arma::colvec& uinit_row, const arma::colvec& uinit_col, const arma::colvec& vinit_row, const arma::colvec& vinit_col, const Eigen::SparseMatrix<double>& premat_row, const Eigen::SparseMatrix<double>& premat_col, const arma::umat& IndMat_row, const arma::umat& IndMat_col, const arma::umat& EOneIndMat_row, const arma::umat& EOneIndMat_col, const arma::umat& ETwoIndMat_row, const arma::umat& ETwoIndMat_col, double rho, int max_iter, int burn_in, bool verbose, int keep);
 RcppExport SEXP _clustRviz_BICARPL2_NF_FRAC(SEXP xSEXP, SEXP nSEXP, SEXP pSEXP, SEXP lambda_initSEXP, SEXP tSEXP, SEXP weights_rowSEXP, SEXP weights_colSEXP, SEXP uinit_rowSEXP, SEXP uinit_colSEXP, SEXP vinit_rowSEXP, SEXP vinit_colSEXP, SEXP premat_rowSEXP, SEXP premat_colSEXP, SEXP IndMat_rowSEXP, SEXP IndMat_colSEXP, SEXP EOneIndMat_rowSEXP, SEXP EOneIndMat_colSEXP, SEXP ETwoIndMat_rowSEXP, SEXP ETwoIndMat_colSEXP, SEXP rhoSEXP, SEXP max_iterSEXP, SEXP burn_inSEXP, SEXP verboseSEXP, SEXP keepSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< arma::colvec >::type x(xSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type x(xSEXP);
     Rcpp::traits::input_parameter< int >::type n(nSEXP);
     Rcpp::traits::input_parameter< int >::type p(pSEXP);
     Rcpp::traits::input_parameter< double >::type lambda_init(lambda_initSEXP);
     Rcpp::traits::input_parameter< double >::type t(tSEXP);
-    Rcpp::traits::input_parameter< arma::colvec >::type weights_row(weights_rowSEXP);
-    Rcpp::traits::input_parameter< arma::colvec >::type weights_col(weights_colSEXP);
-    Rcpp::traits::input_parameter< arma::colvec >::type uinit_row(uinit_rowSEXP);
-    Rcpp::traits::input_parameter< arma::colvec >::type uinit_col(uinit_colSEXP);
-    Rcpp::traits::input_parameter< arma::colvec >::type vinit_row(vinit_rowSEXP);
-    Rcpp::traits::input_parameter< arma::colvec >::type vinit_col(vinit_colSEXP);
-    Rcpp::traits::input_parameter< Eigen::SparseMatrix<double> >::type premat_row(premat_rowSEXP);
-    Rcpp::traits::input_parameter< Eigen::SparseMatrix<double> >::type premat_col(premat_colSEXP);
-    Rcpp::traits::input_parameter< arma::umat >::type IndMat_row(IndMat_rowSEXP);
-    Rcpp::traits::input_parameter< arma::umat >::type IndMat_col(IndMat_colSEXP);
-    Rcpp::traits::input_parameter< arma::umat >::type EOneIndMat_row(EOneIndMat_rowSEXP);
-    Rcpp::traits::input_parameter< arma::umat >::type EOneIndMat_col(EOneIndMat_colSEXP);
-    Rcpp::traits::input_parameter< arma::umat >::type ETwoIndMat_row(ETwoIndMat_rowSEXP);
-    Rcpp::traits::input_parameter< arma::umat >::type ETwoIndMat_col(ETwoIndMat_colSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type weights_row(weights_rowSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type weights_col(weights_colSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type uinit_row(uinit_rowSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type uinit_col(uinit_colSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type vinit_row(vinit_rowSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type vinit_col(vinit_colSEXP);
+    Rcpp::traits::input_parameter< const Eigen::SparseMatrix<double>& >::type premat_row(premat_rowSEXP);
+    Rcpp::traits::input_parameter< const Eigen::SparseMatrix<double>& >::type premat_col(premat_colSEXP);
+    Rcpp::traits::input_parameter< const arma::umat& >::type IndMat_row(IndMat_rowSEXP);
+    Rcpp::traits::input_parameter< const arma::umat& >::type IndMat_col(IndMat_colSEXP);
+    Rcpp::traits::input_parameter< const arma::umat& >::type EOneIndMat_row(EOneIndMat_rowSEXP);
+    Rcpp::traits::input_parameter< const arma::umat& >::type EOneIndMat_col(EOneIndMat_colSEXP);
+    Rcpp::traits::input_parameter< const arma::umat& >::type ETwoIndMat_row(ETwoIndMat_rowSEXP);
+    Rcpp::traits::input_parameter< const arma::umat& >::type ETwoIndMat_col(ETwoIndMat_colSEXP);
     Rcpp::traits::input_parameter< double >::type rho(rhoSEXP);
     Rcpp::traits::input_parameter< int >::type max_iter(max_iterSEXP);
     Rcpp::traits::input_parameter< int >::type burn_in(burn_inSEXP);
@@ -242,30 +242,30 @@ BEGIN_RCPP
 END_RCPP
 }
 // BICARPL1_NF_FRAC
-Rcpp::List BICARPL1_NF_FRAC(arma::colvec x, int n, int p, double lambda_init, double t, arma::colvec weights_row, arma::colvec weights_col, arma::colvec uinit_row, arma::colvec uinit_col, arma::colvec vinit_row, arma::colvec vinit_col, Eigen::SparseMatrix<double> premat_row, Eigen::SparseMatrix<double> premat_col, arma::umat IndMat_row, arma::umat IndMat_col, arma::umat EOneIndMat_row, arma::umat EOneIndMat_col, arma::umat ETwoIndMat_row, arma::umat ETwoIndMat_col, double rho, int max_iter, int burn_in, bool verbose, int keep);
+Rcpp::List BICARPL1_NF_FRAC(const arma::colvec& x, int n, int p, double lambda_init, double t, const arma::colvec& weights_row, const arma::colvec& weights_col, const arma::colvec& uinit_row, const arma::colvec& uinit_col, const arma::colvec& vinit_row, const arma::colvec& vinit_col, const Eigen::SparseMatrix<double>& premat_row, const Eigen::SparseMatrix<double>& premat_col, const arma::umat& IndMat_row, const arma::umat& IndMat_col, const arma::umat& EOneIndMat_row, const arma::umat& EOneIndMat_col, const arma::umat& ETwoIndMat_row, const arma::umat& ETwoIndMat_col, double rho, int max_iter, int burn_in, bool verbose, int keep);
 RcppExport SEXP _clustRviz_BICARPL1_NF_FRAC(SEXP xSEXP, SEXP nSEXP, SEXP pSEXP, SEXP lambda_initSEXP, SEXP tSEXP, SEXP weights_rowSEXP, SEXP weights_colSEXP, SEXP uinit_rowSEXP, SEXP uinit_colSEXP, SEXP vinit_rowSEXP, SEXP vinit_colSEXP, SEXP premat_rowSEXP, SEXP premat_colSEXP, SEXP IndMat_rowSEXP, SEXP IndMat_colSEXP, SEXP EOneIndMat_rowSEXP, SEXP EOneIndMat_colSEXP, SEXP ETwoIndMat_rowSEXP, SEXP ETwoIndMat_colSEXP, SEXP rhoSEXP, SEXP max_iterSEXP, SEXP burn_inSEXP, SEXP verboseSEXP, SEXP keepSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< arma::colvec >::type x(xSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type x(xSEXP);
     Rcpp::traits::input_parameter< int >::type n(nSEXP);
     Rcpp::traits::input_parameter< int >::type p(pSEXP);
     Rcpp::traits::input_parameter< double >::type lambda_init(lambda_initSEXP);
     Rcpp::traits::input_parameter< double >::type t(tSEXP);
-    Rcpp::traits::input_parameter< arma::colvec >::type weights_row(weights_rowSEXP);
-    Rcpp::traits::input_parameter< arma::colvec >::type weights_col(weights_colSEXP);
-    Rcpp::traits::input_parameter< arma::colvec >::type uinit_row(uinit_rowSEXP);
-    Rcpp::traits::input_parameter< arma::colvec >::type uinit_col(uinit_colSEXP);
-    Rcpp::traits::input_parameter< arma::colvec >::type vinit_row(vinit_rowSEXP);
-    Rcpp::traits::input_parameter< arma::colvec >::type vinit_col(vinit_colSEXP);
-    Rcpp::traits::input_parameter< Eigen::SparseMatrix<double> >::type premat_row(premat_rowSEXP);
-    Rcpp::traits::input_parameter< Eigen::SparseMatrix<double> >::type premat_col(premat_colSEXP);
-    Rcpp::traits::input_parameter< arma::umat >::type IndMat_row(IndMat_rowSEXP);
-    Rcpp::traits::input_parameter< arma::umat >::type IndMat_col(IndMat_colSEXP);
-    Rcpp::traits::input_parameter< arma::umat >::type EOneIndMat_row(EOneIndMat_rowSEXP);
-    Rcpp::traits::input_parameter< arma::umat >::type EOneIndMat_col(EOneIndMat_colSEXP);
-    Rcpp::traits::input_parameter< arma::umat >::type ETwoIndMat_row(ETwoIndMat_rowSEXP);
-    Rcpp::traits::input_parameter< arma::umat >::type ETwoIndMat_col(ETwoIndMat_colSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type weights_row(weights_rowSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type weights_col(weights_colSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type uinit_row(uinit_rowSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type uinit_col(uinit_colSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type vinit_row(vinit_rowSEXP);
+    Rcpp::traits::input_parameter< const arma::colvec& >::type vinit_col(vinit_colSEXP);
+    Rcpp::traits::input_parameter< const Eigen::SparseMatrix<double>& >::type premat_row(premat_rowSEXP);
+    Rcpp::traits::input_parameter< const Eigen::SparseMatrix<double>& >::type premat_col(premat_colSEXP);
+    Rcpp::traits::input_parameter< const arma::umat& >::type IndMat_row(IndMat_rowSEXP);
+    Rcpp::traits::input_parameter< const arma::umat& >::type IndMat_col(IndMat_colSEXP);
+    Rcpp::traits::input_parameter< const arma::umat& >::type EOneIndMat_row(EOneIndMat_rowSEXP);
+    Rcpp::traits::input_parameter< const arma::umat& >::type EOneIndMat_col(EOneIndMat_colSEXP);
+    Rcpp::traits::input_parameter< const arma::umat& >::type ETwoIndMat_row(ETwoIndMat_rowSEXP);
+    Rcpp::traits::input_parameter< const arma::umat& >::type ETwoIndMat_col(ETwoIndMat_colSEXP);
     Rcpp::traits::input_parameter< double >::type rho(rhoSEXP);
     Rcpp::traits::input_parameter< int >::type max_iter(max_iterSEXP);
     Rcpp::traits::input_parameter< int >::type burn_in(burn_inSEXP);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,24 +5,27 @@
 #define ARMA_64BIT_WORD
 
 //' @useDynLib clustRviz
-arma::mat UnVec(arma::colvec x, int nrows, int ncols){
+arma::mat UnVec(const arma::colvec& x,
+                int nrows,
+                int ncols){
+
   arma::mat ret(nrows,ncols,arma::fill::zeros);
   arma::uword startidx;
   arma::uword stopidx;
   arma::ucolvec idx;
+
   for(arma::uword coliter = 0; coliter < ncols; coliter++){
     startidx = nrows*coliter;
     stopidx = startidx + nrows - 1;
-    idx = arma::linspace<arma::ucolvec>(startidx,stopidx,nrows);
+    idx = arma::linspace<arma::ucolvec>(startidx, stopidx, nrows);
+
     ret.col(coliter) = x.elem(idx);
   }
   return(ret);
 }
 
 double TwoNorm(arma::colvec x){
-
   return(std::pow(sum(x % x),0.5));
-
 }
 
 Eigen::VectorXd cv_sparse_solve(const Eigen::SparseMatrix<double>& A,
@@ -52,22 +55,36 @@ arma::vec cv_sparse_solve(const Eigen::SparseMatrix<double>& A,
   return solution_arma.col(0);
 }
 
-arma::colvec DMatOpv2(arma::colvec u, int p, arma::umat IndMat, arma::umat EOneIndMat, arma::umat ETwoIndMat ){
+arma::colvec DMatOpv2(const arma::colvec& u,
+                      int p,
+                      const arma::umat& IndMat,
+                      const arma::umat& EOneIndMat,
+                      const arma::umat& ETwoIndMat){
+
   int cardE = EOneIndMat.n_rows;
   arma::ucolvec retIdx(p);
   arma::ucolvec EOneIdx(p);
   arma::ucolvec ETwoIdx(p);
   arma::colvec ret(cardE*p);
+
   for(int l = 0; l < cardE; l++){
     retIdx = IndMat.row(l).t();
     EOneIdx = EOneIndMat.row(l).t();
     ETwoIdx = ETwoIndMat.row(l).t();
+
     ret.elem(retIdx) = u.elem(EOneIdx) - u.elem(ETwoIdx);
   }
+
   return(ret);
 }
 
-arma::colvec DtMatOpv2(arma::colvec v, int n, int p, arma::umat IndMat,arma::umat EOneIndMat, arma::umat ETwoIndMat){
+arma::colvec DtMatOpv2(const arma::colvec& v,
+                       int n,
+                       int p,
+                       const arma::umat& IndMat,
+                       const arma::umat& EOneIndMat,
+                       const arma::umat& ETwoIndMat){
+
   arma::colvec out(n*p,arma::fill::zeros);
   arma::ucolvec vIdx(p);
   arma::ucolvec EOneIdx(p);
@@ -78,9 +95,11 @@ arma::colvec DtMatOpv2(arma::colvec v, int n, int p, arma::umat IndMat,arma::uma
     vIdx = IndMat.row(l).t();
     EOneIdx = EOneIndMat.row(l).t();
     ETwoIdx = ETwoIndMat.row(l).t();
+
     out.elem(EOneIdx) = out.elem(EOneIdx) + v.elem(vIdx);
     out.elem(ETwoIdx) = out.elem(ETwoIdx) - v.elem(vIdx);
   }
+
   return(out);
 }
 
@@ -94,7 +113,11 @@ int sgn(double x){
   return(ret);
 }
 
-arma::colvec ProxL2(arma::colvec delta, int p, arma::colvec scalars, arma::umat IndMat){
+arma::colvec ProxL2(const arma::colvec& delta,
+                    int p,
+                    const arma::colvec& scalars,
+                    const arma::umat& IndMat){
+
   int cardE = IndMat.n_rows;
   arma::ucolvec retIdx(p);
 
@@ -106,11 +129,13 @@ arma::colvec ProxL2(arma::colvec delta, int p, arma::colvec scalars, arma::umat 
   for(int l = 0; l<cardE;l++){
     retIdx = IndMat.row(l).t();
     valvec(1) = 1 - scalars(l)/TwoNorm(delta.elem(retIdx));
+
     if(valvec.has_nan()){
       ret.elem(retIdx) = delta.elem(retIdx);
     } else{
       ret.elem(retIdx) = valvec.max()*delta.elem(retIdx);
     }
+
   }
 
   return(ret);
@@ -118,7 +143,11 @@ arma::colvec ProxL2(arma::colvec delta, int p, arma::colvec scalars, arma::umat 
 
 
 // [[Rcpp::export]]
-arma::colvec ProxL1(arma::colvec delta, int p, double lambda, arma::colvec weights){
+arma::colvec ProxL1(const arma::colvec& delta,
+                    int p,
+                    double lambda,
+                    const arma::colvec& weights){
+
   int cardE = weights.n_rows;
   arma::colvec theta(cardE*p);
   arma::colvec ret(cardE*p);
@@ -137,7 +166,26 @@ arma::colvec ProxL1(arma::colvec delta, int p, double lambda, arma::colvec weigh
 }
 
 // [[Rcpp::export]]
-Rcpp::List CARPL2_VIS_FRAC(arma::colvec x, int n, int p, double lambda_init, arma::colvec weights,arma::colvec uinit, arma::colvec vinit,Eigen::SparseMatrix<double> premat, arma::umat IndMat, arma::umat EOneIndMat, arma::umat ETwoIndMat, double rho = 1, int max_iter = 1e4,int burn_in = 50,bool verbose=false,double back = 0.5, double try_tol = 1e-3,int ti = 15, double t_switch = 1.01,int keep=10){
+Rcpp::List CARPL2_VIS_FRAC(const arma::colvec& x,
+                           int n,
+                           int p,
+                           double lambda_init,
+                           const arma::colvec& weights,
+                           const arma::colvec& uinit,
+                           const arma::colvec& vinit,
+                           const Eigen::SparseMatrix<double>& premat,
+                           const arma::umat& IndMat,
+                           const arma::umat& EOneIndMat,
+                           const arma::umat& ETwoIndMat,
+                           double rho = 1,
+                           int max_iter = 1e4,
+                           int burn_in = 50,
+                           bool verbose=false,
+                           double back = 0.5,
+                           double try_tol = 1e-3,
+                           int ti = 15,
+                           double t_switch = 1.01,
+                           int keep=10){
 
   double t = 1.1;
   int try_iter;
@@ -286,7 +334,23 @@ Rcpp::List CARPL2_VIS_FRAC(arma::colvec x, int n, int p, double lambda_init, arm
 }
 
 // [[Rcpp::export]]
-Rcpp::List CARPL2_NF_FRAC(arma::colvec x, int n, int p, double lambda_init,double t, arma::colvec weights,arma::colvec uinit, arma::colvec vinit,Eigen::SparseMatrix<double> premat, arma::umat IndMat, arma::umat EOneIndMat, arma::umat ETwoIndMat, double rho = 1, int max_iter = 1e4,int burn_in = 50,bool verbose=false,int keep=10){
+Rcpp::List CARPL2_NF_FRAC(const arma::colvec& x,
+                          int n,
+                          int p,
+                          double lambda_init,
+                          double t,
+                          const arma::colvec& weights,
+                          const arma::colvec& uinit,
+                          const arma::colvec& vinit,
+                          const Eigen::SparseMatrix<double>& premat,
+                          const arma::umat& IndMat,
+                          const arma::umat& EOneIndMat,
+                          const arma::umat& ETwoIndMat,
+                          double rho = 1,
+                          int max_iter = 1e4,
+                          int burn_in = 50,
+                          bool verbose=false,
+                          int keep=10){
 
 
   int cardE = EOneIndMat.n_rows;
@@ -382,7 +446,23 @@ Rcpp::List CARPL2_NF_FRAC(arma::colvec x, int n, int p, double lambda_init,doubl
 }
 
 // [[Rcpp::export]]
-Rcpp::List CARPL1_NF_FRAC(arma::colvec x, int n, int p, double lambda_init,double t, arma::colvec weights,arma::colvec uinit, arma::colvec vinit,Eigen::SparseMatrix<double> premat, arma::umat IndMat, arma::umat EOneIndMat, arma::umat ETwoIndMat, double rho = 1, int max_iter = 1e4,int burn_in = 50,bool verbose=false,int keep=10){
+Rcpp::List CARPL1_NF_FRAC(const arma::colvec& x,
+                          int n,
+                          int p,
+                          double lambda_init,
+                          double t,
+                          const arma::colvec& weights,
+                          const arma::colvec& uinit,
+                          const arma::colvec& vinit,
+                          const Eigen::SparseMatrix<double>& premat,
+                          const arma::umat& IndMat,
+                          const arma::umat& EOneIndMat,
+                          const arma::umat& ETwoIndMat,
+                          double rho = 1,
+                          int max_iter = 1e4,
+                          int burn_in = 50,
+                          bool verbose=false,
+                          int keep=10){
 
 
   int cardE = EOneIndMat.n_rows;
@@ -477,7 +557,26 @@ Rcpp::List CARPL1_NF_FRAC(arma::colvec x, int n, int p, double lambda_init,doubl
 }
 
 // [[Rcpp::export]]
-Rcpp::List CARPL1_VIS_FRAC(arma::colvec x, int n, int p, double lambda_init, arma::colvec weights,arma::colvec uinit, arma::colvec vinit,Eigen::SparseMatrix<double> premat, arma::umat IndMat, arma::umat EOneIndMat, arma::umat ETwoIndMat, double rho = 1, int max_iter = 1e4,int burn_in = 50,bool verbose=false,double back = 0.5, double try_tol = 1e-3,int ti = 15, double t_switch = 1.01,int keep=10){
+Rcpp::List CARPL1_VIS_FRAC(const arma::colvec& x,
+                           int n,
+                           int p,
+                           double lambda_init,
+                           const arma::colvec& weights,
+                           const arma::colvec& uinit,
+                           const arma::colvec& vinit,
+                           const Eigen::SparseMatrix<double>& premat,
+                           const arma::umat& IndMat,
+                           const arma::umat& EOneIndMat,
+                           const arma::umat& ETwoIndMat,
+                           double rho = 1,
+                           int max_iter = 1e4,
+                           int burn_in = 50,
+                           bool verbose=false,
+                           double back = 0.5,
+                           double try_tol = 1e-3,
+                           int ti = 15,
+                           double t_switch = 1.01,
+                           int keep=10){
 
   double t = 1.1;
   int try_iter;
@@ -627,7 +726,32 @@ Rcpp::List CARPL1_VIS_FRAC(arma::colvec x, int n, int p, double lambda_init, arm
 }
 
 // [[Rcpp::export]]
-Rcpp::List BICARPL2_VIS(arma::colvec x, int n, int p, double lambda_init,arma::colvec weights_col, arma::colvec weights_row, arma::colvec uinit_row, arma::colvec uinit_col,arma::colvec vinit_row, arma::colvec vinit_col,Eigen::SparseMatrix<double> premat_row,Eigen::SparseMatrix<double> premat_col, arma::umat IndMat_row, arma::umat IndMat_col,arma::umat EOneIndMat_row, arma::umat EOneIndMat_col, arma::umat ETwoIndMat_row, arma::umat ETwoIndMat_col,double rho = 1, int max_iter = 1e4, int burn_in =50, bool verbose=false,bool verbose_inner=false, double try_tol = 1e-3,int ti = 15, double t_switch = 1.01){
+Rcpp::List BICARPL2_VIS(const arma::colvec& x,
+                        int n,
+                        int p,
+                        double lambda_init,
+                        const arma::colvec& weights_col,
+                        const arma::colvec& weights_row,
+                        const arma::colvec& uinit_row,
+                        const arma::colvec& uinit_col,
+                        const arma::colvec& vinit_row,
+                        const arma::colvec& vinit_col,
+                        const Eigen::SparseMatrix<double>& premat_row,
+                        const Eigen::SparseMatrix<double>& premat_col,
+                        const arma::umat& IndMat_row,
+                        const arma::umat& IndMat_col,
+                        const arma::umat& EOneIndMat_row,
+                        const arma::umat& EOneIndMat_col,
+                        const arma::umat& ETwoIndMat_row,
+                        const arma::umat& ETwoIndMat_col,
+                        double rho = 1,
+                        int max_iter = 1e4,
+                        int burn_in =50,
+                        bool verbose=false,
+                        bool verbose_inner=false,
+                        double try_tol = 1e-3,
+                        int ti = 15,
+                        double t_switch = 1.01){
 
   double t = 1.1;
   int try_iter;
@@ -838,7 +962,32 @@ Rcpp::List BICARPL2_VIS(arma::colvec x, int n, int p, double lambda_init,arma::c
 }
 
 // [[Rcpp::export]]
-Rcpp::List BICARPL1_VIS(arma::colvec x, int n, int p, double lambda_init,arma::colvec weights_col, arma::colvec weights_row, arma::colvec uinit_row, arma::colvec uinit_col,arma::colvec vinit_row, arma::colvec vinit_col,Eigen::SparseMatrix<double> premat_row,Eigen::SparseMatrix<double> premat_col, arma::umat IndMat_row, arma::umat IndMat_col,arma::umat EOneIndMat_row, arma::umat EOneIndMat_col, arma::umat ETwoIndMat_row, arma::umat ETwoIndMat_col,double rho = 1, int max_iter = 1e4, int burn_in =50, bool verbose=false,bool verbose_inner=false, double try_tol = 1e-3,int ti = 15, double t_switch = 1.01){
+Rcpp::List BICARPL1_VIS(const arma::colvec& x,
+                        int n,
+                        int p,
+                        double lambda_init,
+                        const arma::colvec& weights_col,
+                        const arma::colvec& weights_row,
+                        const arma::colvec& uinit_row,
+                        const arma::colvec& uinit_col,
+                        const arma::colvec& vinit_row,
+                        const arma::colvec& vinit_col,
+                        const Eigen::SparseMatrix<double>& premat_row,
+                        const Eigen::SparseMatrix<double>& premat_col,
+                        const arma::umat& IndMat_row,
+                        const arma::umat& IndMat_col,
+                        const arma::umat& EOneIndMat_row,
+                        const arma::umat& EOneIndMat_col,
+                        const arma::umat& ETwoIndMat_row,
+                        const arma::umat& ETwoIndMat_col,
+                        double rho = 1,
+                        int max_iter = 1e4,
+                        int burn_in = 50,
+                        bool verbose = false,
+                        bool verbose_inner = false,
+                        double try_tol = 1e-3,
+                        int ti = 15,
+                        double t_switch = 1.01){
 
   double t = 1.1;
   int try_iter;
@@ -1051,7 +1200,30 @@ Rcpp::List BICARPL1_VIS(arma::colvec x, int n, int p, double lambda_init,arma::c
 
 
 // [[Rcpp::export]]
-Rcpp::List BICARPL2_NF_FRAC(arma::colvec x, int n, int p, double lambda_init,double t, arma::colvec weights_row,arma::colvec weights_col,arma::colvec uinit_row, arma::colvec uinit_col,arma::colvec vinit_row,arma::colvec vinit_col,Eigen::SparseMatrix<double> premat_row, Eigen::SparseMatrix<double> premat_col,arma::umat IndMat_row, arma::umat IndMat_col,arma::umat EOneIndMat_row, arma::umat EOneIndMat_col,arma::umat ETwoIndMat_row, arma::umat ETwoIndMat_col, double rho = 1, int max_iter = 1e4,int burn_in = 50,bool verbose=false,int keep=10){
+Rcpp::List BICARPL2_NF_FRAC(const arma::colvec& x,
+                            int n,
+                            int p,
+                            double lambda_init,
+                            double t,
+                            const arma::colvec& weights_row,
+                            const arma::colvec& weights_col,
+                            const arma::colvec& uinit_row,
+                            const arma::colvec& uinit_col,
+                            const arma::colvec& vinit_row,
+                            const arma::colvec& vinit_col,
+                            const Eigen::SparseMatrix<double>& premat_row,
+                            const Eigen::SparseMatrix<double>& premat_col,
+                            const arma::umat& IndMat_row,
+                            const arma::umat& IndMat_col,
+                            const arma::umat& EOneIndMat_row,
+                            const arma::umat& EOneIndMat_col,
+                            const arma::umat& ETwoIndMat_row,
+                            const arma::umat& ETwoIndMat_col,
+                            double rho = 1,
+                            int max_iter = 1e4,
+                            int burn_in = 50,
+                            bool verbose=false,
+                            int keep=10){
 
   int cardE_row = EOneIndMat_row.n_rows;
   int cardE_col = EOneIndMat_col.n_rows;
@@ -1216,7 +1388,30 @@ Rcpp::List BICARPL2_NF_FRAC(arma::colvec x, int n, int p, double lambda_init,dou
 
 
 // [[Rcpp::export]]
-Rcpp::List BICARPL1_NF_FRAC(arma::colvec x, int n, int p, double lambda_init,double t, arma::colvec weights_row,arma::colvec weights_col,arma::colvec uinit_row, arma::colvec uinit_col,arma::colvec vinit_row,arma::colvec vinit_col,Eigen::SparseMatrix<double> premat_row, Eigen::SparseMatrix<double> premat_col,arma::umat IndMat_row, arma::umat IndMat_col,arma::umat EOneIndMat_row, arma::umat EOneIndMat_col,arma::umat ETwoIndMat_row, arma::umat ETwoIndMat_col, double rho = 1, int max_iter = 1e4,int burn_in = 50,bool verbose=false,int keep=10){
+Rcpp::List BICARPL1_NF_FRAC(const arma::colvec& x,
+                            int n,
+                            int p,
+                            double lambda_init,
+                            double t,
+                            const arma::colvec& weights_row,
+                            const arma::colvec& weights_col,
+                            const arma::colvec& uinit_row,
+                            const arma::colvec& uinit_col,
+                            const arma::colvec& vinit_row,
+                            const arma::colvec& vinit_col,
+                            const Eigen::SparseMatrix<double>& premat_row,
+                            const Eigen::SparseMatrix<double>& premat_col,
+                            const arma::umat& IndMat_row,
+                            const arma::umat& IndMat_col,
+                            const arma::umat& EOneIndMat_row,
+                            const arma::umat& EOneIndMat_col,
+                            const arma::umat& ETwoIndMat_row,
+                            const arma::umat& ETwoIndMat_col,
+                            double rho = 1,
+                            int max_iter = 1e4,
+                            int burn_in = 50,
+                            bool verbose=false,
+                            int keep=10){
 
   int cardE_row = EOneIndMat_row.n_rows;
   int cardE_col = EOneIndMat_col.n_rows;
@@ -1379,9 +1574,3 @@ Rcpp::List BICARPL1_NF_FRAC(arma::colvec x, int n, int p, double lambda_init,dou
   return(ret);
 
 }
-
-
-
-
-
-

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,5 @@
 #define ARMA_USE_SUPERLU 0
-// [[Rcpp::depends(RcppArmadillo)]]
-// [[Rcpp::depends(RcppEigen)]]
+
 #include <RcppArmadillo.h>
 #include <RcppEigen.h>
 #define ARMA_64BIT_WORD

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -318,18 +318,13 @@ Rcpp::List CARPL2_VIS_FRAC(const arma::colvec& x,
 
     lambda = lambda*t;
 
-
-
-
-
-
-
-
   }
+
   ret["u.path"] = UPath;
   ret["v.path"] = VPath;
   ret["v.zero.inds"]= vZeroInds_Path;
   ret["lambda.path"] = lambda_path;
+
   return(ret);
 }
 
@@ -429,19 +424,17 @@ Rcpp::List CARPL2_NF_FRAC(const arma::colvec& x,
       vZeroInds_Path.col(path_iter) = vZeroIndsnew;
     }
 
-
-
-
     if(iter >= burn_in){
       lambda = lambda*t;
     }
 
-
   }
+
   ret["u.path"] = UPath;
   ret["v.path"] = VPath;
   ret["v.zero.inds"]= vZeroInds_Path;
   ret["lambda.path"] = lambda_path;
+
   return(ret);
 }
 
@@ -540,19 +533,18 @@ Rcpp::List CARPL1_NF_FRAC(const arma::colvec& x,
       vZeroInds_Path.col(path_iter) = vZeroIndsnew;
     }
 
-
-
-
     if(iter >= burn_in){
       lambda = lambda*t;
     }
 
 
   }
+
   ret["u.path"] = UPath;
   ret["v.path"] = VPath;
   ret["v.zero.inds"]= vZeroInds_Path;
   ret["lambda.path"] = lambda_path;
+
   return(ret);
 }
 
@@ -710,18 +702,13 @@ Rcpp::List CARPL1_VIS_FRAC(const arma::colvec& x,
 
     lambda = lambda*t;
 
-
-
-
-
-
-
-
   }
+
   ret["u.path"] = UPath;
   ret["v.path"] = VPath;
   ret["v.zero.inds"]= vZeroInds_Path;
   ret["lambda.path"] = lambda_path;
+
   return(ret);
 }
 
@@ -797,8 +784,6 @@ Rcpp::List BICARPL2_VIS(const arma::colvec& x,
   int nzerosold_col = 0;
   int nzerosnew_col = 0;
 
-
-
   arma::uword path_iter = 0;
   arma::uword iter = 0;
   arma::mat UPath(n*p,1);
@@ -810,7 +795,6 @@ Rcpp::List BICARPL2_VIS(const arma::colvec& x,
   arma::colvec lambda_path(1);
   lambda_path(path_iter) = lambda_init;
 
-
   arma::colvec vZeroIndsnew_row(cardE_row,arma::fill::zeros);
   arma::colvec vZeroIndsold_row(cardE_row);
   arma::ucolvec vIdx_row(n);
@@ -820,7 +804,6 @@ Rcpp::List BICARPL2_VIS(const arma::colvec& x,
 
   arma::mat vZeroIndsPath_row(cardE_row,1,arma::fill::zeros);
   arma::mat vZeroIndsPath_col(cardE_col,1,arma::fill::zeros);
-
 
   arma::colvec arma_sparse_solver_input_row(n*p);
   arma::colvec arma_sparse_solver_input_col(n*p);
@@ -952,12 +935,14 @@ Rcpp::List BICARPL2_VIS(const arma::colvec& x,
     lambda = lambda*t;
 
   }
+
   ret["u.path"] = UPath;
   ret["v.row.path"] = VPath_row;
   ret["v.col.path"] = VPath_col;
   ret["v.row.zero.inds"] = vZeroIndsPath_row;
   ret["v.col.zero.inds"] = vZeroIndsPath_col;
   ret["lambda.path"] = lambda_path;
+
   return(ret);
 }
 
@@ -1033,8 +1018,6 @@ Rcpp::List BICARPL1_VIS(const arma::colvec& x,
   int nzerosold_col = 0;
   int nzerosnew_col = 0;
 
-
-
   arma::uword path_iter = 0;
   arma::uword iter = 0;
   arma::mat UPath(n*p,1);
@@ -1045,7 +1028,6 @@ Rcpp::List BICARPL1_VIS(const arma::colvec& x,
   VPath_col.col(path_iter)= vinit_col;
   arma::colvec lambda_path(1);
   lambda_path(path_iter) = lambda_init;
-
 
   arma::colvec vZeroIndsnew_row(cardE_row,arma::fill::zeros);
   arma::colvec vZeroIndsold_row(cardE_row);
@@ -1062,6 +1044,7 @@ Rcpp::List BICARPL1_VIS(const arma::colvec& x,
 
   Rcpp::List ret;
   bool rep_iter;
+
   while( ((nzerosnew_row < cardE_row) | (nzerosnew_col < cardE_col)) & (iter < max_iter)){
     iter = iter + 1;
     uold = unew;
@@ -1166,8 +1149,6 @@ Rcpp::List BICARPL1_VIS(const arma::colvec& x,
       t = t_switch;
     }
 
-
-
     if((nzerosnew_row!=nzerosold_row) | (nzerosnew_col!=nzerosold_col)){
       path_iter = path_iter + 1;
       UPath.insert_cols(path_iter,1);
@@ -1185,15 +1166,18 @@ Rcpp::List BICARPL1_VIS(const arma::colvec& x,
       vZeroIndsPath_col.insert_cols(path_iter,1);
       vZeroIndsPath_col.col(path_iter) = vZeroIndsnew_col;
     }
+
     lambda = lambda*t;
 
   }
+
   ret["u.path"] = UPath;
   ret["v.row.path"] = VPath_row;
   ret["v.col.path"] = VPath_col;
   ret["v.row.zero.inds"] = vZeroIndsPath_row;
   ret["v.col.zero.inds"] = vZeroIndsPath_col;
   ret["lambda.path"] = lambda_path;
+
   return(ret);
 }
 
@@ -1272,7 +1256,6 @@ Rcpp::List BICARPL2_NF_FRAC(const arma::colvec& x,
   arma::colvec vZeroIndsnew_col(cardE_col,arma::fill::zeros);
   arma::colvec vZeroIndsold_col(cardE_col,arma::fill::zeros);
 
-
   arma::ucolvec vIdx_row(n);
   arma::ucolvec vIdx_col(p);
 
@@ -1304,8 +1287,6 @@ Rcpp::List BICARPL2_NF_FRAC(const arma::colvec& x,
     nzerosold_row = nzerosnew_row;
     nzerosold_col = nzerosnew_col;
 
-
-
     pt = arma::vectorise(UnVec(pold,p,n).t());
     ut = arma::vectorise(UnVec(uold,p,n).t());
 
@@ -1336,7 +1317,6 @@ Rcpp::List BICARPL2_NF_FRAC(const arma::colvec& x,
     ////////////// End Solve col problem
     qnew = y + qold - unew;
 
-
     for(int l = 0; l<cardE_row; l++){
       vIdx_row = IndMat_row.row(l).t();
       if(sum(vnew_row.elem(vIdx_row)) == 0){
@@ -1352,7 +1332,6 @@ Rcpp::List BICARPL2_NF_FRAC(const arma::colvec& x,
 
     nzerosnew_row = sum(vZeroIndsnew_row);
     nzerosnew_col = sum(vZeroIndsnew_col);
-
 
     if((nzerosnew_row!=nzerosold_row) | (nzerosnew_col!=nzerosold_col)){
       path_iter = path_iter + 1;
@@ -1374,16 +1353,16 @@ Rcpp::List BICARPL2_NF_FRAC(const arma::colvec& x,
     if(iter >= burn_in){
       lambda = lambda*t;
     }
-
   }
+
   ret["u.path"] = UPath;
   ret["v.row.path"] = VPath_row;
   ret["v.col.path"] = VPath_col;
   ret["v.row.zero.inds"] = vZeroIndsPath_row;
   ret["v.col.zero.inds"] = vZeroIndsPath_col;
   ret["lambda.path"] = lambda_path;
-  return(ret);
 
+  return(ret);
 }
 
 
@@ -1460,7 +1439,6 @@ Rcpp::List BICARPL1_NF_FRAC(const arma::colvec& x,
   arma::colvec vZeroIndsnew_col(cardE_col,arma::fill::zeros);
   arma::colvec vZeroIndsold_col(cardE_col,arma::fill::zeros);
 
-
   arma::ucolvec vIdx_row(n);
   arma::ucolvec vIdx_col(p);
 
@@ -1493,8 +1471,6 @@ Rcpp::List BICARPL1_NF_FRAC(const arma::colvec& x,
     nzerosold_row = nzerosnew_row;
     nzerosold_col = nzerosnew_col;
 
-
-
     pt = arma::vectorise(UnVec(pold,p,n).t());
     ut = arma::vectorise(UnVec(uold,p,n).t());
 
@@ -1512,6 +1488,7 @@ Rcpp::List BICARPL1_NF_FRAC(const arma::colvec& x,
 
     y = arma::vectorise(UnVec(yt,n,p).t());
     pnew = uold + pold - y;
+
     ////////////// Solve col problem
     // u update
     // unew = arma::spsolve(premat_col, (1/rho)*(y + qold) + (1/rho)*DtMatOpv2(rho*vold_col - lamold_col,n,p,IndMat_col,EOneIndMat_col,ETwoIndMat_col));
@@ -1532,6 +1509,7 @@ Rcpp::List BICARPL1_NF_FRAC(const arma::colvec& x,
         vZeroIndsnew_row(l) = 1;
       }
     }
+
     for(int l = 0; l<cardE_col; l++){
       vIdx_col = IndMat_col.row(l).t();
       if(sum(vnew_col.elem(vIdx_col)) == 0){
@@ -1541,7 +1519,6 @@ Rcpp::List BICARPL1_NF_FRAC(const arma::colvec& x,
 
     nzerosnew_row = sum(vZeroIndsnew_row);
     nzerosnew_col = sum(vZeroIndsnew_col);
-
 
     if((nzerosnew_row!=nzerosold_row) | (nzerosnew_col!=nzerosold_col)){
       path_iter = path_iter + 1;
@@ -1563,14 +1540,14 @@ Rcpp::List BICARPL1_NF_FRAC(const arma::colvec& x,
     if(iter >= burn_in){
       lambda = lambda*t;
     }
-
   }
+
   ret["u.path"] = UPath;
   ret["v.row.path"] = VPath_row;
   ret["v.col.path"] = VPath_col;
   ret["v.row.zero.inds"] = vZeroIndsPath_row;
   ret["v.col.zero.inds"] = vZeroIndsPath_col;
   ret["lambda.path"] = lambda_path;
-  return(ret);
 
+  return(ret);
 }


### PR DESCRIPTION
Clean up C++ code: 

- Remove unnecessary Rcpp::depends attribute [no behavioral change]
- Formatting line breaks [no behavioral change]
- Simplify sparse solve code / isolate casts
- Use const and pass-by-references wherever possible